### PR TITLE
Raise error if user is not specified for account describe.

### DIFF
--- a/tbs/cmd/account.go
+++ b/tbs/cmd/account.go
@@ -132,6 +132,11 @@ func accountDescribeCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var user *models.User
 			var err error
+
+			if userID == "" && username == "" {
+				return errors.New("Exactly one of --username and --uuid is required.")
+			}
+
 			if userID != "" {
 				user, err = getUserByID(userID)
 			} else {


### PR DESCRIPTION
[fix] - issue #117 - Clarify usage of `account describe` command.
Signed-off-by: John Griebel <johnkgriebel@gmail.com>